### PR TITLE
feat: integrate Monaco Editor (Issue #14)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "twe",
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
+        "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -28,6 +29,7 @@
         "drizzle-orm": "^0.45.1",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.544.0",
+        "monaco-editor": "^0.55.1",
         "nitro": "latest",
         "postgres": "^3.4.7",
         "react": "^19.2.0",
@@ -264,6 +266,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
+
+    "@monaco-editor/react": ["@monaco-editor/react@4.7.0", "", { "dependencies": { "@monaco-editor/loader": "^1.5.0" }, "peerDependencies": { "monaco-editor": ">= 0.25.0 < 1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.0", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA=="],
 
@@ -601,6 +607,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.49.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/type-utils": "8.49.0", "@typescript-eslint/utils": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.49.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A=="],
@@ -786,6 +794,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -1013,6 +1023,8 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
+    "marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
@@ -1102,6 +1114,8 @@
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1260,6 +1274,8 @@
     "srvx": ["srvx@0.9.8", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-RZaxTKJEE/14HYn8COLuUOJAt0U55N9l1Xf6jj+T0GoA01EUH1Xz5JtSUOI+EHn+AEgPCVn7gk6jHJffrr06fQ=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
+    "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -39,6 +40,7 @@
     "drizzle-orm": "^0.45.1",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.544.0",
+    "monaco-editor": "^0.55.1",
     "nitro": "latest",
     "postgres": "^3.4.7",
     "react": "^19.2.0",

--- a/src/components/challenges/CodeEditor.tsx
+++ b/src/components/challenges/CodeEditor.tsx
@@ -1,0 +1,222 @@
+/**
+ * CodeEditor - Monaco Editor wrapper for challenge code input
+ * 
+ * Features:
+ * - JavaScript/TypeScript syntax highlighting
+ * - Dark theme matching app design
+ * - Auto-save to localStorage
+ * - Cmd/Ctrl+Enter to run
+ * - Line numbers and minimap
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import Editor, { OnMount, OnChange, Monaco } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
+import { cn } from '@/lib/utils';
+
+export interface CodeEditorProps {
+    initialCode?: string;
+    language?: 'javascript' | 'typescript' | 'css' | 'html';
+    onChange?: (code: string) => void;
+    onRun?: (code: string) => void;
+    storageKey?: string;
+    readOnly?: boolean;
+    height?: string | number;
+    showMinimap?: boolean;
+    className?: string;
+}
+
+// Custom dark theme matching app design
+const CUSTOM_DARK_THEME: editor.IStandaloneThemeData = {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [
+        { token: 'comment', foreground: '6b7280', fontStyle: 'italic' },
+        { token: 'keyword', foreground: 'c084fc' },
+        { token: 'string', foreground: '4ade80' },
+        { token: 'number', foreground: 'f59e0b' },
+        { token: 'function', foreground: '60a5fa' },
+        { token: 'variable', foreground: 'e2e8f0' },
+        { token: 'type', foreground: '22d3ee' },
+    ],
+    colors: {
+        'editor.background': '#0f172a', // slate-900
+        'editor.foreground': '#e2e8f0', // slate-200
+        'editor.lineHighlightBackground': '#1e293b', // slate-800
+        'editor.selectionBackground': '#334155', // slate-700
+        'editorCursor.foreground': '#22d3ee', // cyan-400
+        'editor.inactiveSelectionBackground': '#1e293b',
+        'editorLineNumber.foreground': '#475569', // slate-600
+        'editorLineNumber.activeForeground': '#94a3b8', // slate-400
+        'editorIndentGuide.background1': '#1e293b',
+        'editorGutter.background': '#0f172a',
+        'scrollbarSlider.background': '#33415580',
+        'scrollbarSlider.hoverBackground': '#47556980',
+    },
+};
+
+export function CodeEditor({
+    initialCode = '',
+    language = 'javascript',
+    onChange,
+    onRun,
+    storageKey,
+    readOnly = false,
+    height = '400px',
+    showMinimap = true,
+    className,
+}: CodeEditorProps) {
+    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+    const monacoRef = useRef<Monaco | null>(null);
+    const [code, setCode] = useState<string>(() => {
+        // Load from localStorage if key provided
+        if (storageKey && typeof window !== 'undefined') {
+            const saved = localStorage.getItem(storageKey);
+            if (saved) return saved;
+        }
+        return initialCode;
+    });
+
+    // Auto-save to localStorage
+    useEffect(() => {
+        if (storageKey && typeof window !== 'undefined') {
+            const debounceTimer = setTimeout(() => {
+                localStorage.setItem(storageKey, code);
+            }, 500);
+            return () => clearTimeout(debounceTimer);
+        }
+    }, [code, storageKey]);
+
+    // Handle code changes
+    const handleChange: OnChange = useCallback(
+        (value) => {
+            const newCode = value || '';
+            setCode(newCode);
+            onChange?.(newCode);
+        },
+        [onChange]
+    );
+
+    // Handle editor mount
+    const handleEditorMount: OnMount = useCallback(
+        (editor, monaco) => {
+            editorRef.current = editor;
+            monacoRef.current = monaco;
+
+            // Define custom theme
+            monaco.editor.defineTheme('customDark', CUSTOM_DARK_THEME);
+            monaco.editor.setTheme('customDark');
+
+            // Add Cmd/Ctrl+Enter keyboard shortcut
+            editor.addAction({
+                id: 'run-code',
+                label: 'Run Code',
+                keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+                run: () => {
+                    onRun?.(code);
+                },
+            });
+
+            // Add Cmd/Ctrl+S to save (prevent default)
+            editor.addAction({
+                id: 'save-code',
+                label: 'Save Code',
+                keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
+                run: () => {
+                    // Auto-save handled by effect, just prevent default
+                    if (storageKey) {
+                        localStorage.setItem(storageKey, code);
+                    }
+                },
+            });
+
+            // Focus editor
+            editor.focus();
+        },
+        [code, onRun, storageKey]
+    );
+
+    // Update editor when onRun changes (to capture latest code)
+    useEffect(() => {
+        if (editorRef.current && monacoRef.current) {
+            // Update the run action with latest code
+            editorRef.current.addAction({
+                id: 'run-code',
+                label: 'Run Code',
+                keybindings: [monacoRef.current.KeyMod.CtrlCmd | monacoRef.current.KeyCode.Enter],
+                run: () => {
+                    onRun?.(code);
+                },
+            });
+        }
+    }, [code, onRun]);
+
+    // Reset to initial code
+    const resetCode = useCallback(() => {
+        setCode(initialCode);
+        onChange?.(initialCode);
+        if (storageKey) {
+            localStorage.removeItem(storageKey);
+        }
+    }, [initialCode, onChange, storageKey]);
+
+    // Get current code
+    const getCode = useCallback(() => {
+        return code;
+    }, [code]);
+
+    return (
+        <div className={cn('rounded-lg overflow-hidden border border-border', className)}>
+            <Editor
+                height={height}
+                language={language}
+                value={code}
+                onChange={handleChange}
+                onMount={handleEditorMount}
+                theme="customDark"
+                options={{
+                    readOnly,
+                    fontSize: 14,
+                    fontFamily: "'JetBrains Mono', 'Fira Code', Consolas, monospace",
+                    minimap: { enabled: showMinimap },
+                    lineNumbers: 'on',
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                    tabSize: 2,
+                    wordWrap: 'on',
+                    padding: { top: 12, bottom: 12 },
+                    renderLineHighlight: 'all',
+                    cursorBlinking: 'smooth',
+                    cursorSmoothCaretAnimation: 'on',
+                    smoothScrolling: true,
+                    formatOnPaste: true,
+                    formatOnType: true,
+                    folding: true,
+                    bracketPairColorization: { enabled: true },
+                    autoClosingBrackets: 'always',
+                    autoClosingQuotes: 'always',
+                    suggestOnTriggerCharacters: true,
+                    quickSuggestions: true,
+                    contextmenu: true,
+                }}
+                loading={
+                    <div className="flex items-center justify-center h-full bg-slate-900 text-muted-foreground">
+                        Loading editor...
+                    </div>
+                }
+            />
+        </div>
+    );
+}
+
+// Export helper methods
+export function useCodeEditor() {
+    const editorRef = useRef<{
+        getCode: () => string;
+        resetCode: () => void;
+    } | null>(null);
+
+    return editorRef;
+}
+
+export default CodeEditor;

--- a/src/components/challenges/index.ts
+++ b/src/components/challenges/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Challenge Components
+ * 
+ * Export all challenge-related components.
+ */
+
+export { CodeEditor } from './CodeEditor';
+export type { CodeEditorProps } from './CodeEditor';


### PR DESCRIPTION
CodeEditor Component (src/components/challenges/CodeEditor.tsx):
- Monaco Editor integration with @monaco-editor/react
- Custom dark theme matching app design (slate-900 background)
- JavaScript/TypeScript syntax highlighting
- Color-coded tokens (keywords, strings, numbers, functions)
- Auto-save to localStorage with debouncing
- Keyboard shortcuts:
  - Cmd/Ctrl+Enter to run code
  - Cmd/Ctrl+S to save
- Line numbers and minimap
- Bracket pair colorization
- Auto-closing brackets and quotes
- Smooth cursor animation
- Word wrap
- Configurable height and read-only mode

Dependencies added:
- @monaco-editor/react
- monaco-editor

Index file (src/components/challenges/index.ts):
- Exports CodeEditor and types

Build verified successfully ✅