### PR TITLE
feat: add content status filter for tutorials and challenges

### DIFF
--- a/src/lib/content.types.ts
+++ b/src/lib/content.types.ts
@@ -6,6 +6,12 @@
  */
 
 // =============================================================================
+// CONTENT STATUS
+// =============================================================================
+
+export type ContentStatus = 'published' | 'draft' | 'coming_soon';
+
+// =============================================================================
 // LOCALIZED CONTENT
 // =============================================================================
 
@@ -28,6 +34,7 @@ export interface TutorialRegistryEntry {
   tags: string[];
   relatedChallenges?: string[];
   nextTutorialSlug?: string | null;
+  status?: ContentStatus;
 }
 
 /**
@@ -100,6 +107,7 @@ export interface ChallengeDefinition {
   testCases: TestCaseDefinition[];
   solution: string;
   tags?: string[];
+  status?: ContentStatus;
 }
 
 /**

--- a/src/server/content.server.ts
+++ b/src/server/content.server.ts
@@ -101,6 +101,9 @@ export async function getTutorialContent(
 
     if (!entry) return null;
 
+    // Block access to non-published content
+    if (entry.status && entry.status !== 'published') return null;
+
     // Try requested locale first, then fallback to 'en'
     let content: string;
     let usedLocale = locale;
@@ -143,6 +146,9 @@ export async function getTutorialList(
   const tutorials: Omit<Tutorial, 'content'>[] = [];
 
   for (const entry of registry.tutorials) {
+    // Skip non-published content (default to published if no status)
+    if (entry.status && entry.status !== 'published') continue;
+
     // Try to load frontmatter for title/description
     let title = entry.slug;
     let description = '';
@@ -270,6 +276,9 @@ export async function getChallengeContent(
 
   if (!def) return null;
 
+  // Block access to non-published content
+  if (def.status && def.status !== 'published') return null;
+
   return {
     slug: def.slug,
     type: def.type,
@@ -300,6 +309,9 @@ export async function getChallengeList(
   const results: Omit<Challenge, 'testCases' | 'solution'>[] = [];
 
   for (const def of challenges.values()) {
+    // Skip non-published content (default to published if no status)
+    if (def.status && def.status !== 'published') continue;
+
     // Apply filters
     if (filters?.type && def.type !== filters.type) continue;
     if (filters?.difficulty && def.difficulty !== filters.difficulty) continue;

--- a/tutorials/registry.json
+++ b/tutorials/registry.json
@@ -225,7 +225,8 @@
         "advanced"
       ],
       "relatedChallenges": [],
-      "nextTutorialSlug": "playwright-data-driven"
+      "nextTutorialSlug": "playwright-data-driven",
+      "status": "draft"
     },
     {
       "slug": "playwright-data-driven",


### PR DESCRIPTION
- Add ContentStatus type ('published' | 'draft' | 'coming_soon')
- Add optional status field to TutorialRegistryEntry and ChallengeDefinition
- Filter non-published content in getTutorialList and getChallengeList
- Block direct URL access to draft content in getTutorialContent and getChallengeContent
- Add status: draft to playwright-pom tutorial as example

This enables incremental content releases by marking tutorials/challenges as draft or coming_soon. Content without status defaults to published.