### PR TITLE
feat(bugs): implement rate limiting and fix double submissions

### DIFF
--- a/src/components/BugReportDialog.tsx
+++ b/src/components/BugReportDialog.tsx
@@ -50,6 +50,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { authQueryOptions } from '@/lib/auth.query';
 import { trackEvent } from '@/lib/analytics';
 import { createBugReport } from '@/server/bug-reports.fn';
+import { showAchievementToast } from './achievement-toast';
 
 // Helper functions need to be moved or keep them here but typed correctly
 const getBugReportSchema = (t: TFunction) =>
@@ -107,6 +108,7 @@ interface BugReportDialogProps {
 export function BugReportDialog({ trigger, className }: BugReportDialogProps) {
   const { t } = useTranslation(['bugs', 'common']);
   const [open, setOpen] = useState(false);
+  const [localSubmitting, setLocalSubmitting] = useState(false);
   const { data: auth } = useSuspenseQuery(authQueryOptions);
   const session = auth;
   const isLoggedIn = !!session?.user;
@@ -142,10 +144,14 @@ export function BugReportDialog({ trigger, className }: BugReportDialogProps) {
 
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       toast.success(t('bugs:toast.success.title'), {
         description: t('bugs:toast.success.description'),
       });
+
+      if (data.newAchievement) {
+        showAchievementToast(data.newAchievement);
+      }
 
       // Track analytics
       trackEvent('bug_report_submitted', { title: form.getValues('title') });
@@ -161,7 +167,11 @@ export function BugReportDialog({ trigger, className }: BugReportDialogProps) {
   });
 
   const onSubmit = (data: BugReportFormData) => {
-    submitMutation.mutate(data);
+    if (localSubmitting) return;
+    setLocalSubmitting(true);
+    submitMutation.mutate(data, {
+      onSettled: () => setLocalSubmitting(false),
+    });
   };
 
   return (
@@ -362,7 +372,7 @@ export function BugReportDialog({ trigger, className }: BugReportDialogProps) {
             <Button
               type="submit"
               form="bug-report-form"
-              disabled={submitMutation.isPending}
+              disabled={submitMutation.isPending || localSubmitting}
               variant="destructive"
             >
               {submitMutation.isPending ? (

--- a/src/routes/$locale/tutorials/$slug.tsx
+++ b/src/routes/$locale/tutorials/$slug.tsx
@@ -30,6 +30,7 @@ import {
   type TOCItem,
 } from '@/components/tutorials/TableOfContents';
 import i18n from '@/lib/i18n';
+import { showAchievementToasts } from '@/components/achievement-toast';
 
 export const Route = createFileRoute('/$locale/tutorials/$slug')({
   component: TutorialDetailPage,
@@ -99,6 +100,7 @@ function TutorialDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [readingProgress, setReadingProgress] = useState(0);
+  const [localSubmitting, setLocalSubmitting] = useState(false);
   const [showAuthGuard, setShowAuthGuard] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
   const { data: auth } = useSuspenseQuery(authQueryOptions);
@@ -128,7 +130,7 @@ function TutorialDetailPage() {
       if (!result.success) throw new Error(result.error);
       return result;
     },
-    onSuccess: async () => {
+    onSuccess: async (result) => {
       toast.success(t('tutorials:toasts.completed'));
       await queryClient.invalidateQueries({ queryKey: ['tutorial', slug] });
       await queryClient.invalidateQueries({ queryKey: ['tutorials'] });
@@ -136,8 +138,10 @@ function TutorialDetailPage() {
       await queryClient.invalidateQueries({ queryKey: ['profile'] });
       await queryClient.invalidateQueries({ queryKey: ['leaderboard'] });
 
-      // Achievement toasts would go here if tutorials awarded achievements
-      // Currently tutorials only award XP
+
+      if (result.data?.newAchievements && result.data.newAchievements.length > 0) {
+        showAchievementToasts(result.data.newAchievements);
+      }
     },
     onError: () => {
       toast.error(t('tutorials:toasts.failed'));
@@ -449,10 +453,16 @@ function TutorialDetailPage() {
                         setShowAuthGuard(true);
                         return;
                       }
-                      markCompleteMutation.mutate();
+                      if (localSubmitting) return;
+                      setLocalSubmitting(true);
+                      markCompleteMutation.mutate(undefined, {
+                        onSettled: () => setLocalSubmitting(false),
+                      });
                     }}
                     disabled={
-                      markCompleteMutation.isPending || displayProgress < 100
+                      markCompleteMutation.isPending ||
+                      localSubmitting ||
+                      displayProgress < 100
                     }
                   >
                     <CheckCircle2 className="h-4 w-4 mr-2" />

--- a/src/server/bug-reports.fn.ts
+++ b/src/server/bug-reports.fn.ts
@@ -5,7 +5,10 @@ import { db } from '@/db';
 import { bugReports } from '@/db/schema';
 import { logger } from '@/lib/logger';
 import { auth } from './auth.server';
+import { optionalAuthMiddleware } from './auth.mw';
 import { createGitHubIssue, formatBugReportBody } from './github.server';
+import { getEarnedAchievementIds, awardAchievements } from '@/lib/stats';
+import { createRateLimitMiddleware } from './rate-limit.mw';
 
 const BugReportSchema = z.object({
   title: z.string().min(5, 'Title must be at least 5 characters').max(200),
@@ -27,6 +30,14 @@ const BugReportSchema = z.object({
 });
 
 export const createBugReport = createServerFn({ method: 'POST' })
+  .middleware([
+    optionalAuthMiddleware,
+    createRateLimitMiddleware({
+      key: 'bug-report',
+      limit: 3,
+      windowMinutes: 60,
+    }),
+  ])
   .inputValidator((data: unknown) => BugReportSchema.parse(data))
   .handler(async ({ data: input }) => {
     try {
@@ -78,6 +89,25 @@ export const createBugReport = createServerFn({ method: 'POST' })
         `[BugReport] New bug report created: ${report.id} - "${title}" (${severity})`,
       );
 
+      // Award Bug Squasher achievement (only for authenticated users, first report only)
+      let newAchievement: { id: string; name: string; icon: string } | null = null;
+      if (userId) {
+        try {
+          const alreadyEarned = await getEarnedAchievementIds(userId);
+          if (!alreadyEarned.has('bug-squasher')) {
+            await awardAchievements(userId, ['bug-squasher']);
+            newAchievement = {
+              id: 'bug-squasher',
+              name: 'Bug Squasher',
+              icon: '🐞',
+            };
+            logger.info(`[Achievements] Bug Squasher awarded to user ${userId}`);
+          }
+        } catch (error) {
+          logger.error('Error awarding Bug Squasher achievement:', error);
+        }
+      }
+
       // Create GitHub Issue (non-blocking)
       const issueBody = formatBugReportBody({
         reportId: report.id,
@@ -106,6 +136,7 @@ export const createBugReport = createServerFn({ method: 'POST' })
           severity: report.severity,
           status: report.status,
           createdAt: report.createdAt,
+          newAchievement,
         },
         message:
           'Bug report submitted successfully. Thank you for your feedback!',

--- a/src/server/rate-limit.mw.ts
+++ b/src/server/rate-limit.mw.ts
@@ -1,0 +1,117 @@
+/**
+ * Rate Limit Middleware Factory
+ *
+ * Provides a reusable, in-memory rate limiting middleware for server functions.
+ * Uses a simple Map to store request counts with automatic cleanup.
+ *
+ * Usage:
+ * export const myFn = createServerFn({ method: "POST" })
+ *   .middleware([createRateLimitMiddleware({ key: "my-fn", limit: 10, windowMinutes: 60 })])
+ *   .handler(...)
+ */
+
+import { createMiddleware } from '@tanstack/react-start';
+import { getRequestHeaders } from '@tanstack/react-start/server';
+import { getWebRequest } from '@tanstack/react-start/server';
+
+interface RateLimitEntry {
+    count: number;
+    resetAt: number;
+}
+
+// Global store for rate limits (persists across requests in the same process)
+// Key format: `${endpointKey}:${identifier}`
+const rateLimitStore = new Map<string, RateLimitEntry>();
+
+// Cleanup interval (every 5 minutes)
+const CLEANUP_INTERVAL = 5 * 60 * 1000;
+
+let cleanupTimer: NodeJS.Timeout | null = null;
+
+function cleanupStore() {
+    const now = Date.now();
+    for (const [key, entry] of rateLimitStore.entries()) {
+        if (now > entry.resetAt) {
+            rateLimitStore.delete(key);
+        }
+    }
+}
+
+// Ensure cleanup runs
+if (!cleanupTimer) {
+    cleanupTimer = setInterval(cleanupStore, CLEANUP_INTERVAL);
+}
+
+/**
+ * Get client identifier (IP or User ID)
+ * Prioritizes:
+ * 1. User ID (if authenticated)
+ * 2. X-Forwarded-For (if behind proxy/load balancer)
+ * 3. Socket remote address
+ */
+function getClientIdentifier(
+    headers: Headers,
+    userId?: string | null
+): string {
+    if (userId) return `user:${userId}`;
+
+    // Check standard proxy headers
+    const forwardedFor = headers.get('x-forwarded-for');
+    if (forwardedFor) {
+        // Get the first IP in the list (client IP)
+        return forwardedFor.split(',')[0].trim();
+    }
+
+    const realIp = headers.get('x-real-ip');
+    if (realIp) return realIp;
+
+    // Fallback for local dev or direct connection
+    return 'unknown-ip';
+}
+
+/**
+ * Create a rate limiting middleware
+ */
+export function createRateLimitMiddleware(options: {
+    key: string; // Unique identifier for this rate limit bucket (e.g., 'bug-report')
+    limit: number; // Max requests within window
+    windowMinutes: number; // Time window in minutes
+}) {
+    return createMiddleware().server(async ({ next, context }) => {
+        const headers = getRequestHeaders();
+
+        // We try to get userId from context (if authMiddleware ran before this)
+        // @ts-expect-error - context is unknown here, but we check safely
+        const userId = context?.user?.id as string | undefined;
+
+        const identifier = getClientIdentifier(headers, userId);
+        const storeKey = `${options.key}:${identifier}`;
+        const now = Date.now();
+        const windowMs = options.windowMinutes * 60 * 1000;
+
+        let entry = rateLimitStore.get(storeKey);
+
+        // If entry doesn't exist or expired, create new
+        if (!entry || now > entry.resetAt) {
+            entry = {
+                count: 0,
+                resetAt: now + windowMs,
+            };
+            rateLimitStore.set(storeKey, entry);
+        }
+
+        // Check limit
+        if (entry.count >= options.limit) {
+            const resetInMinutes = Math.ceil((entry.resetAt - now) / 60000);
+            throw new Error(
+                `Rate limit exceeded. Please try again in ${resetInMinutes} minute${resetInMinutes !== 1 ? 's' : ''}.`
+            );
+        }
+
+        // Increment count
+        entry.count++;
+
+        // Proceed
+        return next();
+    });
+}

--- a/src/server/tutorials.fn.ts
+++ b/src/server/tutorials.fn.ts
@@ -11,6 +11,13 @@ import {
   getTutorialContent,
   getNextTutorial,
 } from './content.server';
+import { checkAchievements } from '@/lib/achievements';
+import {
+  getUserStats,
+  getEarnedAchievementIds,
+  awardAchievements,
+} from '@/lib/stats';
+import { logger } from '@/lib/logger';
 
 // Helper for localizable fields (still needed for challenges)
 const getLocalizedValue = (value: unknown, locale: string): string => {
@@ -346,26 +353,37 @@ export const completeTutorial = createServerFn({ method: 'POST' })
           return { success: false, error: 'Tutorial not found' };
         }
 
-        const [newTutorial] = await db
-          .insert(tutorials)
-          .values({
-            slug: tutorialContent.slug,
-            title: { en: tutorialContent.title, id: tutorialContent.title },
-            description: {
-              en: tutorialContent.description,
-              id: tutorialContent.description,
-            },
-            content: {
-              en: tutorialContent.content,
-              id: tutorialContent.content,
-            },
-            order: tutorialContent.order,
-            estimatedMinutes: tutorialContent.estimatedMinutes,
-            tags: tutorialContent.tags,
-            isPublished: true,
-          })
-          .returning();
-        tutorial = newTutorial;
+        try {
+          const [newTutorial] = await db
+            .insert(tutorials)
+            .values({
+              slug: tutorialContent.slug,
+              title: { en: tutorialContent.title, id: tutorialContent.title },
+              description: {
+                en: tutorialContent.description,
+                id: tutorialContent.description,
+              },
+              content: {
+                en: tutorialContent.content,
+                id: tutorialContent.content,
+              },
+              order: tutorialContent.order,
+              estimatedMinutes: tutorialContent.estimatedMinutes,
+              tags: tutorialContent.tags,
+              isPublished: true,
+            })
+            .returning();
+          tutorial = newTutorial;
+        } catch (err) {
+          // If insertion failed (likely race condition on unique slug), try to fetch it again
+          tutorial = await db.query.tutorials.findFirst({
+            where: eq(tutorials.slug, slug),
+          });
+
+          if (!tutorial) {
+            throw err; // Re-throw if legitimate error
+          }
+        }
       }
 
       // Check existing progress
@@ -413,6 +431,33 @@ export const completeTutorial = createServerFn({ method: 'POST' })
           .where(eq(users.id, userId));
       }
 
+      // Check and award achievements (for tutorials and streaks)
+      let newAchievements: { id: string; name: string; icon: string }[] = [];
+      try {
+        const userStats = await getUserStats(userId);
+        const alreadyEarned = await getEarnedAchievementIds(userId);
+        const earnedAchievements = checkAchievements(userStats, alreadyEarned);
+
+        if (earnedAchievements.length > 0) {
+          await awardAchievements(
+            userId,
+            earnedAchievements.map((a) => a.id),
+          );
+
+          newAchievements = earnedAchievements.map((a) => ({
+            id: a.id,
+            name: a.name,
+            icon: a.icon,
+          }));
+
+          logger.info(
+            `[Achievements] Tutorial completion triggered: ${earnedAchievements.map((a) => a.name).join(', ')}`,
+          );
+        }
+      } catch (error) {
+        logger.error('Error checking achievements after tutorial:', error);
+      }
+
       // Increment view/completion count
       await db
         .update(tutorials)
@@ -426,6 +471,7 @@ export const completeTutorial = createServerFn({ method: 'POST' })
         data: {
           isCompleted: true,
           xpAwarded: wasAlreadyCompleted ? 0 : 25,
+          newAchievements,
         },
       };
     } catch (error) {


### PR DESCRIPTION
- Add reusable rate-limit middleware (in-memory)
- Limit bug reports to 3 per hour per user/IP
- Fix double toast bug on tutorial completion (race condition + client guard)
- Fix double toast bug on bug reports (client guard)
- Fix ReferenceError in bug report success handler