### PR TITLE
fix(mobile): resolve Badge ReferenceError in EditorPanel

### DIFF
--- a/src/components/challenges/playground/EditorPanel.tsx
+++ b/src/components/challenges/playground/EditorPanel.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { RotateCcw, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { CodeEditor } from '../CodeEditor';
 import { FileExplorer } from '../FileExplorer';
 import { MultiTabEditor } from '../MultiTabEditor';


### PR DESCRIPTION
Add missing Badge import that was causing ReferenceError on mobile view when opening challenges.