### PR TITLE
fix(mobile): hide code editor for selector challenges

### DIFF
--- a/src/components/challenges/playground/PlaygroundMobileLayout.tsx
+++ b/src/components/challenges/playground/PlaygroundMobileLayout.tsx
@@ -191,20 +191,22 @@ export function PlaygroundMobileLayout({
                                     />
                                 </div>
                             )}
-                            <div className="flex-1 min-h-0 flex flex-col">
-                                <EditorPanel
-                                    challenge={challenge}
-                                    state={state}
-                                    isMobile={true}
-                                    onRunCode={handleRunCode}
-                                    onReset={handleReset}
-                                    onFileChange={handleFileChange}
-                                    onSelectFile={handleSelectFile}
-                                    onCloseFile={handleCloseFile}
-                                    onCodeChange={(code) => state.setCode(code)}
-                                    onReady={() => state.setIsLayoutReady(true)}
-                                />
-                            </div>
+                            {!isSelectorChallenge && (
+                                <div className="flex-1 min-h-0 flex flex-col">
+                                    <EditorPanel
+                                        challenge={challenge}
+                                        state={state}
+                                        isMobile={true}
+                                        onRunCode={handleRunCode}
+                                        onReset={handleReset}
+                                        onFileChange={handleFileChange}
+                                        onSelectFile={handleSelectFile}
+                                        onCloseFile={handleCloseFile}
+                                        onCodeChange={(code) => state.setCode(code)}
+                                        onReady={() => state.setIsLayoutReady(true)}
+                                    />
+                                </div>
+                            )}
                         </div>
                     </TabsContent>
 


### PR DESCRIPTION
Update PlaygroundMobileLayout to conditionally render the EditorPanel only when the challenge is NOT a selector challenge. This saves vertical space and aligns mobile behavior with desktop behavior for selector-based challenges.