### PR TITLE
fix: add base URL to new URL() constructor for Bun compatibility

### DIFF
--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -14,7 +14,7 @@ console.log(`🚀 ${env.charAt(0).toUpperCase() + env.slice(1)} server starting 
 Bun.serve({
     port: PORT,
     async fetch(req) {
-        const url = new URL(req.url);
+        const url = new URL(req.url, `http://localhost:${PORT}`);
         const path = url.pathname;
 
         // Security: basic directory traversal protection


### PR DESCRIPTION
Without a base URL, `new URL('/')` throws `TypeError: '/' cannot be parsed as a URL` on Bun since `req.url` is a relative path. Adding `http://localhost:${PORT}` as base fixes the URL parsing in `Bun.serve()`.