### PR TITLE
fix: replace curl with wget for Docker healthcheck

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:3000/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

Docker healthcheck currently uses `curl` but the `oven/bun:1` image doesn't have curl installed. This causes the container to be marked as `unhealthy` in Docker even though the app responds correctly with HTTP 200.

## Fix

Replace `curl` healthcheck with `wget --spider` which is available in the BusyBox-based oven/bun:1 image.

### Before
```yaml
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:3000/]